### PR TITLE
Don't make assumptions about the baseURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   run: function(conf, app, url, callback) {
     var server;
     var agent = supertest.agent(url);
-    var baseURL = '/api/';
+    var baseURL = '/';
 
     if (typeof conf !== 'object') {
       return callback('Failed to load test configuration from file');

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ The test file (e.g. `test/loopbackAPI.test.js`)
 var loopbackApiTesting = require('loopback-api-testing');
 var tests = require('./apiTestConfig.json');
 var server = require('../server/server.js');
-var url = 'http://localhost:3000';
+var url = 'http://localhost:3000/api';
 
 loopbackApiTesting.run(tests, server, url, function(err) {
   if (err) {


### PR DESCRIPTION
Let the user pass it as part of the `url` argument.
