### PR TITLE
Run tests while loopback api is running already

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,15 @@ module.exports = {
       return callback('Failed to load test configuration from file');
     }
 
-    before(function(done) {
-      server = app.listen(done);
-    });
+    if (app) {
+      before(function(done) {
+        server = app.listen(done);
+      });
 
-    after(function(done) {
-      server.close(done);
-    });
+      after(function(done) {
+        server.close(done);
+      });
+    }
 
     describe('Loopback API', function() {
       async.each(conf, function(c, asyncCallback) {


### PR DESCRIPTION
While developing i have to stop my server an run tests which to me is kind of repetitive, this change enables developers to continue there developing process and run tests at the same time,  i think this would be a nice to have.

Example:
loopbackApiTesting.run(tests, null, url, function(err) {
  if (err) {
    console.log(err);
  }
});
