### PR TITLE
Make the error stack include stack from res.body.error

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ module.exports = {
         var description = 'should respond '+c.expect+' on '+authenticationDescription+' '+c.method+' requests to /'+c.model;
         var parsedMethod;
 
-        var loginBlock = function(loginCallback) { 
-          return loginCallback(null, null); 
+        var loginBlock = function(loginCallback) {
+          return loginCallback(null, null);
         };
 
         if (c.method.toUpperCase() === 'GET') {
@@ -104,6 +104,14 @@ module.exports = {
             .expect(c.expect)
             .end(function(err, res) {
               if (err) {
+                if ( res.body.error ) {
+                  var error = res.body.error;
+                  err.message = err.message +": "+error.message;
+                  var stack = err.stack.split("\n").slice(1);
+                  stack.push("    ...");
+                  stack = stack.concat(error.stack.split("\n").slice(1));
+                  err.stack = stack.join("\n");
+                }
                 done(err);
                 return asyncCallback();
               } else {


### PR DESCRIPTION
This will show the stack from the API like so:

```
  20) Loopback API should respond 200 on unauthenticated GET requests to /stuff/1/ok:
     expected 200 "OK", got 400 "Bad Request": Cannot find mapping for ok:1: null
      at Test._assertStatus (node_modules/supertest/lib/test.js:232:12)
      at Test._assertFunction (node_modules/supertest/lib/test.js:247:11)
      at Test.assert (node_modules/supertest/lib/test.js:148:18)
      at assert (node_modules/supertest/lib/test.js:127:12)
      at node_modules/supertest/lib/test.js:124:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:703:3)
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/index.js:922:12)
      at endReadableNT (_stream_readable.js:921:12)
      ...
      at src/mixins/dostuff.js:24:17
      at node_modules/loopback-datasource-juggler/lib/relation-definition.js:1893:18
      at node_modules/loopback-datasource-juggler/lib/dao.js:2003:62
      at node_modules/loopback-datasource-juggler/lib/dao.js:1932:9
      at node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:396:17
      at async.each (node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:153:20)
      at _asyncMap (node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:390:13)
      at Object.map (node_modules/loopback-datasource-juggler/node_modules/async/lib/async.js:361:23)
      at allCb (node_modules/loopback-datasource-juggler/lib/dao.js:1860:13)
      at node_modules/loopback-connector-redis/lib/redis.js:621:9
      at Client.multi (node_modules/loopback-connector-redis/lib/redis.js:106:49)
      at handleKeys (node_modules/loopback-connector-redis/lib/redis.js:601:12)
      at node_modules/loopback-connector-redis/lib/redis.js:587:5
      at node_modules/loopback-connector-redis/lib/redis.js:97:9
      at try_callback (node_modules/loopback-connector-redis/node_modules/redis/index.js:592:9)
      at RedisClient.return_reply (node_modules/loopback-connector-redis/node_modules/redis/index.js:685:13)
      at ReplyParser.<anonymous> (node_modules/loopback-connector-redis/node_modules/redis/index.js:321:14)
      at ReplyParser.send_reply (node_modules/loopback-connector-redis/node_modules/redis/lib/parser/javascript.js:300:10)
      at ReplyParser.execute (node_modules/loopback-connector-redis/node_modules/redis/lib/parser/javascript.js:211:22)
      at RedisClient.on_data (node_modules/loopback-connector-redis/node_modules/redis/index.js:547:27)
      at Socket.<anonymous> (node_modules/loopback-connector-redis/node_modules/redis/index.js:102:14)
      at readableAddChunk (_stream_readable.js:153:18)
      at Socket.Readable.push (_stream_readable.js:111:10)
      at TCP.onread (net.js:536:20)

```

I think the merge conflict is from the previous PR I did that you rejected, but is still in my master.  But should be pretty easy for you to copy this code in if you want it.